### PR TITLE
emit 'full' event all the time when queue is full

### DIFF
--- a/lib/bagpipe.js
+++ b/lib/bagpipe.js
@@ -75,7 +75,7 @@ Bagpipe.prototype.push = function (method) {
     callback(err);
   }
 
-  if (this.queue.length > 1) {
+  if (this.queue.length) {
     this.emit('full', this.queue.length);
   }
 
@@ -90,6 +90,8 @@ Bagpipe.prototype.next = function () {
   var that = this;
   if (that.active < that.limit && that.queue.length) {
     var req = that.queue.shift();
+    that.emit('full', that.queue.length);
+
     that.run(req.method, req.args);
   }
 };


### PR DESCRIPTION
emit 'full' event all the time when queue is full, not only 'push' op.
